### PR TITLE
Pdf preview is not working on grid

### DIFF
--- a/models/Asset/Document.php
+++ b/models/Asset/Document.php
@@ -112,7 +112,7 @@ class Document extends Model\Asset
             return new Document\ImageThumbnail(null);
         }
 
-        if (!$this->getCustomSetting('document_page_count')) {
+        if ($deferred && !$this->getCustomSetting('document_page_count')) {
             Logger::info('Image thumbnail not yet available, processing is done asynchronously.');
             TmpStore::add(sprintf('asset_document_conversion_%d', $this->getId()), $this->getId(), 'asset-document-conversion');
 


### PR DESCRIPTION
When you upload a new PDF, the thumbnail image is not generated immediatly and replaced by "filetype-not-supported.svg" image.

![Capture du 2020-03-06 15-42-58](https://user-images.githubusercontent.com/8455611/76093798-e4ca2000-5fc1-11ea-8153-7f79d992374a.png)
